### PR TITLE
Add '-' sign for losses in postgame modal

### DIFF
--- a/src/components/PostgameModal/helperComponents.tsx
+++ b/src/components/PostgameModal/helperComponents.tsx
@@ -34,7 +34,7 @@ export const StatLine: React.FC<StatLineProps> = (props) => {
                         /
           {totalBets}
         </p>
-        <p className={isWin ? 'green-text' : 'red-text'}>+${isWin ? props.winnings : props.losses}</p>
+        <p className={isWin ? 'green-text' : 'red-text'}>{isWin ? '+' : '-'}${isWin ? props.winnings : props.losses}</p>
       </div>
     </div>
   );


### PR DESCRIPTION
# Title

Prepend losses with '-' instead of '+'

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] Unit/integration tests
- [ ] Documentation

## Tickets

- [#111](https://app.zenhub.com/workspaces/betmate-60612106ee6e6e000ee3aad2/issues/dali-lab/betmate-frontend/111)

