### PR TITLE
Add auth listeners for Heap identification

### DIFF
--- a/src/store/sagas/heap/handlers.ts
+++ b/src/store/sagas/heap/handlers.ts
@@ -1,0 +1,22 @@
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+import { apply } from 'redux-saga/effects';
+import { CreateUserActions, JwtSignInActions, SignInUserActions } from 'types/resources/auth';
+
+export function* handleAuthHeap(action: CreateUserActions | SignInUserActions | JwtSignInActions) {
+  try {
+    if (action.status !== 'SUCCESS') return;
+    yield apply(window.heap, window.heap.identify, [action.payload.user._id]);
+  } catch (error) {
+    console.log(error);
+    // maybe retry heap.identify later?
+  }
+}
+
+export function* handleDeauthHeap() {
+  try {
+    yield apply(window.heap, window.heap.resetIdentity, []);
+  } catch (error) {
+    console.log(error);
+    // maybe retry heap.resetIdentity later?
+  }
+}

--- a/src/store/sagas/heap/index.ts
+++ b/src/store/sagas/heap/index.ts
@@ -1,0 +1,9 @@
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+import { takeEvery } from 'redux-saga/effects';
+import { takeSuccess } from '../utils';
+import { handleAuthHeap, handleDeauthHeap } from './handlers';
+
+export default function* heapSaga() {
+  yield takeEvery(takeSuccess('CREATE_USER', 'SIGN_IN_USER', 'JWT_SIGN_IN'), handleAuthHeap);
+  yield takeEvery(takeSuccess('DEAUTH_USER'), handleDeauthHeap);
+}

--- a/src/store/sagas/index.ts
+++ b/src/store/sagas/index.ts
@@ -8,14 +8,15 @@ import wagerSaga from 'store/sagas/wager';
 import leaderboardSaga from 'store/sagas/leaderboard';
 
 import watchSockets from 'store/sagas/sockets';
+import heapSaga from './heap';
 
 function* rootSaga() {
   yield spawn(authSaga);
   yield spawn(chessgroundSaga);
   yield spawn(gameSaga);
+  yield spawn(heapSaga);
   yield spawn(leaderboardSaga);
   yield spawn(wagerSaga);
-
   yield spawn(watchSockets);
 }
 

--- a/src/types/modules/global.d.ts
+++ b/src/types/modules/global.d.ts
@@ -1,0 +1,11 @@
+interface Heap {
+  identify: (id: string) => void
+  resetIdentity: () => void
+  addUserProperties: (fields: Record<string, string>) => void
+}
+
+export declare global {
+  interface Window {
+    heap: Heap;
+  }
+}


### PR DESCRIPTION
# Title

To allow identification of users with Heap, add in sagas to listen to auth events.
