### PR TITLE
fix: remove slash from production url

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,7 +2,7 @@
 // Server URL for making backend requests
 // eslint-disable-next-line no-nested-ternary
 export const ROOT_URL = process.env.TARGET_ENV === 'prod'
-  ? 'https://betmate-backend-prod.herokuapp.com/'
+  ? 'https://betmate-backend-prod.herokuapp.com'
   : process.env.TARGET_ENV === 'dev'
     ? 'https://betmate-backend-dev.herokuapp.com'
     : 'http://localhost:9090';


### PR DESCRIPTION
Fix production url, which had an extra "/" causing the websocket not to work.